### PR TITLE
Fix load_config cannot render erb lines.

### DIFF
--- a/lib/veritrans/config.rb
+++ b/lib/veritrans/config.rb
@@ -96,7 +96,7 @@ class Veritrans
     #
     def load_config(filename, yml_section = nil)
       yml_file, file_yml_section = filename.to_s.split('#')
-      config_data = YAML.load(File.read(yml_file))
+      config_data = YAML.load(ERB.new(File.read(yml_file)).result)
 
       yml_section ||= file_yml_section
       if defined?(Rails) && !yml_section

--- a/spec/configs/veritrans_with_erb.yml
+++ b/spec/configs/veritrans_with_erb.yml
@@ -1,0 +1,2 @@
+client_key: <%= ENV['CLIENT_KEY'] %>
+server_key: <%= ENV['SERVER_KEY'] %>

--- a/spec/veritrans_config_spec.rb
+++ b/spec/veritrans_config_spec.rb
@@ -2,6 +2,7 @@ describe Veritrans::Config do
 
   before do
     hide_const("Rails")
+    hide_const("ENV")
   end
 
   it "should set Veritras as self inside config block" do
@@ -42,6 +43,16 @@ describe Veritrans::Config do
     })
 
     data = Veritrans.config.load_config("./spec/configs/veritrans.yml")
+    data.should == {"client_key" => "test_client_key", "server_key" => "test_server_key"}
+  end
+
+  it "should load config and render erb lines" do
+    stub_const('ENV', {
+      'CLIENT_KEY' => 'test_client_key',
+      'SERVER_KEY' => 'test_server_key'
+    })
+
+    data = Veritrans.config.load_config("./spec/configs/veritrans_with_erb.yml")
     data.should == {"client_key" => "test_client_key", "server_key" => "test_server_key"}
   end
 


### PR DESCRIPTION
Patch for https://github.com/veritrans/veritrans-ruby/issues/21.

So we can do 

```
production:
  client_key: <%= ENV['VERITRANS_CLIENT_KEY'] %>
  server_key: <%= ENV['VERITRANS_SERVER_KEY'] %>
  api_host: <%= ENV['VERITRANS_API_HOST'] %>
```

in `veritrans.yml`

Thanks