### PR TITLE
Fix: prevent double Accept header on API call to avoid 403 issue

### DIFF
--- a/lib/veritrans/client.rb
+++ b/lib/veritrans/client.rb
@@ -85,10 +85,10 @@ class Veritrans
       request_options = {
         :path => URI.parse(url).path,
         :headers => {
-          :Authorization => auth_header || basic_auth_header(config.server_key),
-          :Accept => "application/json",
-          :"Content-Type" => "application/json",
-          :"User-Agent" => "Veritrans ruby gem #{Veritrans::VERSION}"
+          "Authorization" => auth_header || basic_auth_header(config.server_key),
+          "Accept" => "application/json",
+          "Content-Type" => "application/json",
+          "User-Agent" => "Veritrans ruby gem #{Veritrans::VERSION}"
         }
       }
 


### PR DESCRIPTION
Fix: https://github.com/veritrans/veritrans-ruby/issues/33

More description: 
https://github.com/veritrans/veritrans-ruby/issues/33#issuecomment-563925893

Looks like this is some issue on Excon (HTTP library used on this lib)
A) **[Sample issue]** using these config:
```
request_options = {
        :path => URI.parse(url).path,
        :headers => {
          :Authorization => auth_header || basic_auth_header(config.server_key),
          :Accept => "application/json",
          :"Content-Type" => "application/json",
          :"User-Agent" => "Veritrans ruby gem #{Veritrans::VERSION}"
        }
      }
```
resulted in HTTP request with double `Accept` header:
```
POST /v2/charge HTTP/1.1
User-Agent: excon/0.70.0
Accept: */*
Accept: application/json
```
Which cause API server to fail to parse JSON, which response `status_code" : "403", "status_message" : "Invalid JSON format or header"`
Demo: https://repl.it/repls/JovialAggravatingOs

B) **[Sample fixed]** While using these config:
```
request_options = {
        :path => URI.parse(url).path,
        :headers => {
          "Authorization" => auth_header || basic_auth_header(config.server_key),
          "Accept" => "application/json",
          "Content-Type" => "application/json",
          "User-Agent" => "Veritrans ruby gem #{Veritrans::VERSION}"
        }
      }
```
Result in HTTP request with proper `Accept` header (only 1).
Which will be able to be parsed by API, and API will response correctly.
Demo: https://repl.it/repls/BelatedDarkblueCoins

This PR is to implement point B.